### PR TITLE
Fixed font location in theme

### DIFF
--- a/css/theme/gdicool.css
+++ b/css/theme/gdicool.css
@@ -1,24 +1,24 @@
 @font-face {
   font-family: "Gotham";
-  src: local("Gotham"), url("fonts/Gotham/Gotham-Medium.otf") format("opentype");
+  src: local("Gotham"), url("../../lib/font/Gotham-Medium.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Book";
-  src: local("Gotham-Book"), url("fonts/Gotham/Gotham-Book.otf") format("opentype");
+  src: local("Gotham-Book"), url("../../lib/font/Gotham-Book.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Italic";
-  src: local("Gotham-Italic"), url("fonts/Gotham/Gotham-MediumItalic.otf") format("opentype");
+  src: local("Gotham-Italic"), url("../../lib/font/Gotham-MediumItalic.otf") format("opentype");
   font-weight: normal;
   font-style: italic; }
 
 @font-face {
   font-family: "Gotham-Bold";
-  src: local("Gotham-Bold"), url("fonts/Gotham/Gotham-Bold.otf") format("opentype");
+  src: local("Gotham-Bold"), url("../../lib/font/Gotham-Bold.otf") format("opentype");
   font-weight: bold;
   font-style: bold; }
 

--- a/css/theme/gdidefault.css
+++ b/css/theme/gdidefault.css
@@ -1,24 +1,24 @@
 @font-face {
   font-family: "Gotham";
-  src: local("Gotham"), url("fonts/Gotham/Gotham-Medium.otf") format("opentype");
+  src: local("Gotham"), url("../../lib/font/Gotham-Medium.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Book";
-  src: local("Gotham-Book"), url("fonts/Gotham/Gotham-Book.otf") format("opentype");
+  src: local("Gotham-Book"), url("../../lib/font/Gotham-Book.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Italic";
-  src: local("Gotham-Italic"), url("fonts/Gotham/Gotham-MediumItalic.otf") format("opentype");
+  src: local("Gotham-Italic"), url("../../lib/font/Gotham-MediumItalic.otf") format("opentype");
   font-weight: normal;
   font-style: italic; }
 
 @font-face {
   font-family: "Gotham-Bold";
-  src: local("Gotham-Bold"), url("fonts/Gotham/Gotham-Bold.otf") format("opentype");
+  src: local("Gotham-Bold"), url("../../lib/font/Gotham-Bold.otf") format("opentype");
   font-weight: bold;
   font-style: bold; }
 

--- a/css/theme/gdilight.css
+++ b/css/theme/gdilight.css
@@ -1,24 +1,24 @@
 @font-face {
   font-family: "Gotham";
-  src: local("Gotham"), url("fonts/Gotham/Gotham-Medium.otf") format("opentype");
+  src: local("Gotham"), url("../../lib/font/Gotham-Medium.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Book";
-  src: local("Gotham-Book"), url("fonts/Gotham/Gotham-Book.otf") format("opentype");
+  src: local("Gotham-Book"), url("../../lib/font/Gotham-Book.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Italic";
-  src: local("Gotham-Italic"), url("fonts/Gotham/Gotham-MediumItalic.otf") format("opentype");
+  src: local("Gotham-Italic"), url("../../lib/font/Gotham-MediumItalic.otf") format("opentype");
   font-weight: normal;
   font-style: italic; }
 
 @font-face {
   font-family: "Gotham-Bold";
-  src: local("Gotham-Bold"), url("fonts/Gotham/Gotham-Bold.otf") format("opentype");
+  src: local("Gotham-Bold"), url("../../lib/font/Gotham-Bold.otf") format("opentype");
   font-weight: bold;
   font-style: bold; }
 

--- a/css/theme/gdisunny.css
+++ b/css/theme/gdisunny.css
@@ -1,24 +1,24 @@
 @font-face {
   font-family: "Gotham";
-  src: local("Gotham"), url("fonts/Gotham/Gotham-Medium.otf") format("opentype");
+  src: local("Gotham"), url("../../lib/font/Gotham-Medium.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Book";
-  src: local("Gotham-Book"), url("fonts/Gotham/Gotham-Book.otf") format("opentype");
+  src: local("Gotham-Book"), url("../../lib/font/Gotham-Book.otf") format("opentype");
   font-weight: normal;
   font-style: normal; }
 
 @font-face {
   font-family: "Gotham-Italic";
-  src: local("Gotham-Italic"), url("fonts/Gotham/Gotham-MediumItalic.otf") format("opentype");
+  src: local("Gotham-Italic"), url("../../lib/font/Gotham-MediumItalic.otf") format("opentype");
   font-weight: normal;
   font-style: italic; }
 
 @font-face {
   font-family: "Gotham-Bold";
-  src: local("Gotham-Bold"), url("fonts/Gotham/Gotham-Bold.otf") format("opentype");
+  src: local("Gotham-Bold"), url("../../lib/font/Gotham-Bold.otf") format("opentype");
   font-weight: bold;
   font-style: bold; }
 

--- a/css/theme/template/settings.scss
+++ b/css/theme/template/settings.scss
@@ -1,32 +1,34 @@
-// Base settings for all themes that can optionally be 
+// Base settings for all themes that can optionally be
 // overridden by the super-theme
+
+$reveal-font-path: "../../lib/font" !default;
 
 // Include theme-specific fonts
 @font-face {
 	font-family: "Gotham";
 	src: local("Gotham"),
-	url("fonts/Gotham/Gotham-Medium.otf") format("opentype");
+	url("#{$reveal-font-path}/Gotham-Medium.otf") format("opentype");
 	font-weight: normal;
 	font-style: normal;
 }
 @font-face {
 	font-family: "Gotham-Book";
 	src: local("Gotham-Book"),
-	url("fonts/Gotham/Gotham-Book.otf") format("opentype");
+	url("#{$reveal-font-path}/Gotham-Book.otf") format("opentype");
 	font-weight: normal;
 	font-style: normal;
 }
 @font-face {
 	font-family: "Gotham-Italic";
 	src: local("Gotham-Italic"),
-	url("fonts/Gotham/Gotham-MediumIta.otf") format("opentype");
+	url("#{$reveal-font-path}/Gotham-MediumIta.otf") format("opentype");
 	font-weight: normal;
 	font-style: italic;
 }
 @font-face {
 	font-family: "Gotham-Bold";
 	src: local("Gotham-Bold"),
-	url("fonts/Gotham/Gotham-Bold.otf") format("opentype");
+	url("#{$reveal-font-path}/Gotham-Bold.otf") format("opentype");
 	font-weight: bold;
 	font-style: bold;
 }


### PR DESCRIPTION
`Gotham-*` font was being included from a non-existent location before which caused a 404.

Fixed by putting a `$reveal-font-path` in the SCSS and then building into a rendered gdi theme CSS files.
