### PR TITLE
Updated print css so p, ul, and div are visible on white paper.

### DIFF
--- a/css/print/pdf.css
+++ b/css/print/pdf.css
@@ -50,6 +50,10 @@ body, p, td, li, div {
 	font-size: 18pt;
 }
 
+p, ul, div { 
+	color: black; 
+}
+
 /* SECTION 4: Set heading font face, sizes, and color.
    Diffrentiate your headings from your body text.
    Perhaps use a large sans-serif for distinction. */


### PR DESCRIPTION
A lot of the slide was being printed as a very light gray on white paper, which made it unreadable. Set some of the text to black on pdf css.